### PR TITLE
Update Const.lua

### DIFF
--- a/Util/Const.lua
+++ b/Util/Const.lua
@@ -420,4 +420,3 @@ Arenalogs.CONST.PVP_SEVERITY_RANK = {
 Arenalogs.CONST.MAP_ABBREVIATIONS = {
 
 }
-}


### PR DESCRIPTION
fixes `Arenalogs/Util/Const.lua:423: unexpected symbol near '}'`